### PR TITLE
agents: add delegation-first worker runtime aliases

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -268,6 +268,24 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("documents delegation-first worker routing and backend aliases", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_spawn"],
+    });
+
+    expect(prompt).toContain("Delegation-first: keep this core session conversation-focused");
+    expect(prompt).toContain(
+      'Routing policy: simple tasks -> `runtime: "subagent"` (lightweight child session); complex or long-running tasks -> `runtime: "acp"`.',
+    );
+    expect(prompt).toContain(
+      'Worker backend preference: `runtime: "omx"`, `"omc"`, or `"omo"` routes through ACP',
+    );
+    expect(prompt).toContain(
+      "Use direct execution/tool calls in this core session only when delegation is unavailable",
+    );
+  });
+
   it("omits ACP harness guidance when ACP is disabled", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -279,6 +297,9 @@ describe("buildAgentSystemPrompt", () => {
       'For requests like "do this in codex/claude code/gemini", treat it as ACP harness intent',
     );
     expect(prompt).not.toContain('runtime="acp" requires `agentId`');
+    expect(prompt).not.toContain(
+      'Worker backend preference: `runtime: "omx"`, `"omc"`, or `"omo"`',
+    );
     expect(prompt).not.toContain("not ACP harness ids");
     expect(prompt).toContain("- sessions_spawn: Spawn an isolated sub-agent session");
     expect(prompt).toContain("- agents_list: List OpenClaw agent ids allowed for sessions_spawn");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -444,13 +444,23 @@ export function buildAgentSystemPrompt(params: {
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
+    hasSessionsSpawn
+      ? "Delegation-first: keep this core session conversation-focused, and route execution work (code edits, repo operations, config changes, build/test/check commands) through `sessions_spawn` workers by default."
+      : "",
+    hasSessionsSpawn
+      ? 'Routing policy: simple tasks -> `runtime: "subagent"` (lightweight child session); complex or long-running tasks -> `runtime: "acp"`.'
+      : "",
     ...(hasSessionsSpawn && acpEnabled
       ? [
           'For requests like "do this in codex/claude code/gemini", treat it as ACP harness intent and call `sessions_spawn` with `runtime: "acp"`.',
           'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`) unless the user asks otherwise.',
+          'Worker backend preference: `runtime: "omx"`, `"omc"`, or `"omo"` routes through ACP and defaults `agentId` to that backend label unless `agentId` is set explicitly.',
           "Set `agentId` explicitly unless `acp.defaultAgent` is configured, and do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows.",
         ]
       : []),
+    hasSessionsSpawn
+      ? "Use direct execution/tool calls in this core session only when delegation is unavailable or the user explicitly asks for in-session execution."
+      : "",
     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",
     "",
     "## Tool Call Style",

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -115,4 +115,64 @@ describe("sessions_spawn tool", () => {
     );
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
+
+  it.each(["omx", "omc", "omo"] as const)(
+    "routes backend alias runtime=%s to ACP and defaults agentId",
+    async (runtimeAlias) => {
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:123",
+        agentThreadId: "456",
+      });
+
+      const result = await tool.execute("call-3", {
+        runtime: runtimeAlias,
+        task: "run delegated worker task",
+      });
+
+      expect(result.details).toMatchObject({
+        status: "accepted",
+        childSessionKey: "agent:codex:acp:1",
+        runId: "run-acp",
+      });
+      expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: "run delegated worker task",
+          agentId: runtimeAlias,
+        }),
+        expect.objectContaining({
+          agentSessionKey: "agent:main:main",
+        }),
+      );
+      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+      hoisted.spawnAcpDirectMock.mockClear();
+    },
+  );
+
+  it("prefers explicit agentId over backend alias default", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+      agentAccountId: "default",
+      agentTo: "channel:123",
+      agentThreadId: "456",
+    });
+
+    await tool.execute("call-4", {
+      runtime: "omx",
+      task: "use explicit worker agent",
+      agentId: "custom-worker",
+    });
+
+    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "use explicit worker agent",
+        agentId: "custom-worker",
+      }),
+      expect.anything(),
+    );
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -6,7 +6,23 @@ import { SUBAGENT_SPAWN_MODES, spawnSubagentDirect } from "../subagent-spawn.js"
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 
-const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
+const ACP_WORKER_RUNTIME_ALIASES = ["omx", "omc", "omo"] as const;
+const ACP_WORKER_RUNTIME_ALIAS_SET = new Set<string>(ACP_WORKER_RUNTIME_ALIASES);
+const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp", ...ACP_WORKER_RUNTIME_ALIASES] as const;
+
+function resolveSessionsSpawnRuntime(runtime: unknown): {
+  runtime: "subagent" | "acp";
+  implicitAgentId?: string;
+} {
+  const normalized = typeof runtime === "string" ? runtime.trim().toLowerCase() : "";
+  if (normalized === "acp") {
+    return { runtime: "acp" };
+  }
+  if (ACP_WORKER_RUNTIME_ALIAS_SET.has(normalized)) {
+    return { runtime: "acp", implicitAgentId: normalized };
+  }
+  return { runtime: "subagent" };
+}
 
 const SessionsSpawnToolSchema = Type.Object({
   task: Type.String(),
@@ -41,14 +57,16 @@ export function createSessionsSpawnTool(opts?: {
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound.',
+      'Spawn an isolated session (runtime="subagent", "acp", "omx", "omc", or "omo"). mode="run" is one-shot and mode="session" is persistent/thread-bound.',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const task = readStringParam(params, "task", { required: true });
       const label = typeof params.label === "string" ? params.label.trim() : "";
-      const runtime = params.runtime === "acp" ? "acp" : "subagent";
-      const requestedAgentId = readStringParam(params, "agentId");
+      const runtimeSelection = resolveSessionsSpawnRuntime(params.runtime);
+      const runtime = runtimeSelection.runtime;
+      const requestedAgentId =
+        readStringParam(params, "agentId") ?? runtimeSelection.implicitAgentId;
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");


### PR DESCRIPTION
## Summary
- add delegation-first orchestration guidance in the core system prompt so execution tasks default to worker delegation via `sessions_spawn`
- add simple/complex routing guidance (`subagent` for lightweight work, `acp` for heavier work)
- extend `sessions_spawn` runtime support with `omx`, `omc`, and `omo` aliases that route through ACP and default `agentId` to the alias when not provided
- add regression tests for runtime alias routing and prompt guidance

## Testing
- corepack pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts src/agents/system-prompt.test.ts src/agents/openclaw-tools.sessions.test.ts

Closes #3.
