### PR TITLE
feat: add persona profile toggle for experimental Mr.W mode

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -28,6 +28,7 @@ type ResolvedAgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  personaProfile?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
@@ -127,6 +128,7 @@ export function resolveAgentConfig(
     name: typeof entry.name === "string" ? entry.name : undefined,
     workspace: typeof entry.workspace === "string" ? entry.workspace : undefined,
     agentDir: typeof entry.agentDir === "string" ? entry.agentDir : undefined,
+    personaProfile: typeof entry.personaProfile === "string" ? entry.personaProfile : undefined,
     model:
       typeof entry.model === "string" || (entry.model && typeof entry.model === "object")
         ? entry.model

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -66,27 +66,29 @@ export function buildSystemPrompt(params: {
     agentId: params.agentId,
   });
   const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
-    config: params.config,
-    agentId: params.agentId,
-    workspaceDir: params.workspaceDir,
-    cwd: process.cwd(),
-    runtime: {
-      host: "openclaw",
-      os: `${os.type()} ${os.release()}`,
-      arch: os.arch(),
-      node: process.version,
-      model: params.modelDisplay,
-      defaultModel: defaultModelLabel,
-      shell: detectRuntimeShell(),
-    },
-  });
+  const { runtimeInfo, userTimezone, userTime, userTimeFormat, personaProfile } =
+    buildSystemPromptParams({
+      config: params.config,
+      agentId: params.agentId,
+      workspaceDir: params.workspaceDir,
+      cwd: process.cwd(),
+      runtime: {
+        host: "openclaw",
+        os: `${os.type()} ${os.release()}`,
+        arch: os.arch(),
+        node: process.version,
+        model: params.modelDisplay,
+        defaultModel: defaultModelLabel,
+        shell: detectRuntimeShell(),
+      },
+    });
   const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
     defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
+    personaProfile,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: ownerDisplay.ownerDisplay,
     ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -619,24 +619,25 @@ export async function runEmbeddedAttempt(
       agentId: sessionAgentId,
     });
     const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-    const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
-      config: params.config,
-      agentId: sessionAgentId,
-      workspaceDir: effectiveWorkspace,
-      cwd: process.cwd(),
-      runtime: {
-        host: machineName,
-        os: `${os.type()} ${os.release()}`,
-        arch: os.arch(),
-        node: process.version,
-        model: `${params.provider}/${params.modelId}`,
-        defaultModel: defaultModelLabel,
-        shell: detectRuntimeShell(),
-        channel: runtimeChannel,
-        capabilities: runtimeCapabilities,
-        channelActions,
-      },
-    });
+    const { runtimeInfo, userTimezone, userTime, userTimeFormat, personaProfile } =
+      buildSystemPromptParams({
+        config: params.config,
+        agentId: sessionAgentId,
+        workspaceDir: effectiveWorkspace,
+        cwd: process.cwd(),
+        runtime: {
+          host: machineName,
+          os: `${os.type()} ${os.release()}`,
+          arch: os.arch(),
+          node: process.version,
+          model: `${params.provider}/${params.modelId}`,
+          defaultModel: defaultModelLabel,
+          shell: detectRuntimeShell(),
+          channel: runtimeChannel,
+          capabilities: runtimeCapabilities,
+          channelActions,
+        },
+      });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
     const promptMode = resolvePromptModeForSession(params.sessionKey);
     const docsPath = await resolveOpenClawDocsPath({
@@ -653,6 +654,7 @@ export async function runEmbeddedAttempt(
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,
+      personaProfile,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -13,6 +13,7 @@ export function buildEmbeddedSystemPrompt(params: {
   defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
+  personaProfile?: string;
   ownerNumbers?: string[];
   ownerDisplay?: "raw" | "hash";
   ownerDisplaySecret?: string;
@@ -58,6 +59,7 @@ export function buildEmbeddedSystemPrompt(params: {
     defaultThinkLevel: params.defaultThinkLevel,
     reasoningLevel: params.reasoningLevel,
     extraSystemPrompt: params.extraSystemPrompt,
+    personaProfile: params.personaProfile,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: params.ownerDisplay,
     ownerDisplaySecret: params.ownerDisplaySecret,

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -13,9 +13,15 @@ async function makeRepoRoot(root: string): Promise<void> {
   await fs.mkdir(path.join(root, ".git"), { recursive: true });
 }
 
-function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; cwd?: string }) {
+function buildParams(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  cwd?: string;
+  agentId?: string;
+}) {
   return buildSystemPromptParams({
     config: params.config,
+    agentId: params.agentId,
     workspaceDir: params.workspaceDir,
     cwd: params.cwd,
     runtime: {
@@ -100,5 +106,40 @@ describe("buildSystemPromptParams repo root", () => {
     const { runtimeInfo } = buildParams({ workspaceDir });
 
     expect(runtimeInfo.repoRoot).toBeUndefined();
+  });
+});
+
+describe("buildSystemPromptParams persona profile", () => {
+  it("uses defaults persona profile when no per-agent override exists", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          personaProfile: "mrw-anime-experimental",
+        },
+        list: [{ id: "main" }],
+      },
+    };
+
+    const result = buildParams({ config, agentId: "main" });
+    expect(result.personaProfile).toBe("mrw-anime-experimental");
+  });
+
+  it("prefers agent persona profile over defaults", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          personaProfile: "mrw-anime-experimental",
+        },
+        list: [
+          { id: "main", personaProfile: " " },
+          { id: "otaku-lab", personaProfile: "mrw-anime-experimental-v2" },
+        ],
+      },
+    };
+
+    expect(buildParams({ config, agentId: "main" }).personaProfile).toBe("mrw-anime-experimental");
+    expect(buildParams({ config, agentId: "otaku-lab" }).personaProfile).toBe(
+      "mrw-anime-experimental-v2",
+    );
   });
 });

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { findGitRoot } from "../infra/git-root.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import {
   formatUserTime,
   resolveUserTimeFormat,
@@ -30,6 +31,7 @@ export type SystemPromptRuntimeParams = {
   userTimezone: string;
   userTime?: string;
   userTimeFormat?: ResolvedTimeFormat;
+  personaProfile?: string;
 };
 
 export function buildSystemPromptParams(params: {
@@ -47,6 +49,10 @@ export function buildSystemPromptParams(params: {
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
   const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
   const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+  const personaProfile = resolvePersonaProfile({
+    config: params.config,
+    agentId: params.agentId,
+  });
   return {
     runtimeInfo: {
       agentId: params.agentId,
@@ -56,7 +62,26 @@ export function buildSystemPromptParams(params: {
     userTimezone,
     userTime,
     userTimeFormat,
+    personaProfile,
   };
+}
+
+function resolvePersonaProfile(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+}): string | undefined {
+  const config = params.config;
+  if (!config) {
+    return undefined;
+  }
+  const agentOverride = params.agentId
+    ? resolveAgentConfig(config, params.agentId)?.personaProfile?.trim()
+    : undefined;
+  if (agentOverride) {
+    return agentOverride;
+  }
+  const defaultsValue = config.agents?.defaults?.personaProfile?.trim();
+  return defaultsValue || undefined;
 }
 
 function resolveRepoRoot(params: {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -326,6 +326,31 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Reminder: commit your changes in this workspace after edits.");
   });
 
+  it("injects generic persona profile guidance when a custom profile id is configured", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      personaProfile: "my-custom-profile",
+    });
+
+    expect(prompt).toContain("## Persona Profile");
+    expect(prompt).toContain("Active persona profile: my-custom-profile");
+    expect(prompt).toContain(
+      "Honor this profile while still following higher-priority safety and policy rules.",
+    );
+  });
+
+  it("injects mrw-anime experimental persona guidance when enabled", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      personaProfile: "mrw-anime-experimental",
+    });
+
+    expect(prompt).toContain("## Persona Profile (Experimental)");
+    expect(prompt).toContain("Mr.W + Cowboy Bebop");
+    expect(prompt).toContain("Pacing: brief opener");
+    expect(prompt).toContain("Copyright: never quote");
+  });
+
   it("shows timezone section for 12h, 24h, and timezone-only modes", () => {
     const cases = [
       {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -17,6 +17,48 @@ import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 export type PromptMode = "full" | "minimal" | "none";
 type OwnerIdDisplay = "raw" | "hash";
 
+type PersonaProfilePreset = {
+  label: string;
+  lines: string[];
+};
+
+const PERSONA_PROFILE_PRESETS: Record<string, PersonaProfilePreset> = {
+  "mrw-anime-experimental": {
+    label: "Mr.W + Cowboy Bebop (Spike-inspired, original writing only)",
+    lines: [
+      "Voice: calm, sharp, and understated; avoid loud or overly cute phrasing.",
+      "Pacing: brief opener, then one practical insight, then a clear next step.",
+      "Emotional cadence: cool and composed first, warmer when the user shows stress or doubt.",
+      "Reaction style: dry wit and grounded confidence; avoid sarcastic hostility.",
+      "Structure: acknowledgement -> options or recommendation -> direct action prompt.",
+      "Copyright: never quote or closely mimic copyrighted character dialogue.",
+    ],
+  },
+};
+
+function buildPersonaProfileSection(personaProfileRaw: string | undefined) {
+  const personaProfile = personaProfileRaw?.trim();
+  if (!personaProfile) {
+    return [];
+  }
+  const normalized = personaProfile.toLowerCase();
+  const preset = PERSONA_PROFILE_PRESETS[normalized];
+  if (!preset) {
+    return [
+      "## Persona Profile",
+      `Active persona profile: ${personaProfile}`,
+      "Honor this profile while still following higher-priority safety and policy rules.",
+      "",
+    ];
+  }
+  return [
+    "## Persona Profile (Experimental)",
+    `Active persona profile: ${preset.label} [id: ${personaProfile}]`,
+    ...preset.lines.map((line) => `- ${line}`),
+    "",
+  ];
+}
+
 function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
@@ -191,6 +233,7 @@ export function buildAgentSystemPrompt(params: {
   defaultThinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   extraSystemPrompt?: string;
+  personaProfile?: string;
   ownerNumbers?: string[];
   ownerDisplay?: OwnerIdDisplay;
   ownerDisplaySecret?: string;
@@ -403,6 +446,7 @@ export function buildAgentSystemPrompt(params: {
     availableTools,
     citationsMode: params.memoryCitationsMode,
   });
+  const personaProfileSection = buildPersonaProfileSection(params.personaProfile);
   const docsSection = buildDocsSection({
     docsPath: params.docsPath,
     isMinimal,
@@ -418,6 +462,7 @@ export function buildAgentSystemPrompt(params: {
   const lines = [
     "You are a personal assistant running inside OpenClaw.",
     "",
+    ...personaProfileSection,
     "## Tooling",
     "Tool availability (filtered by policy):",
     "Tool names are case-sensitive. Call tools exactly as listed.",

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -82,20 +82,21 @@ export async function resolveCommandsSystemPromptBundle(
     agentId: sessionAgentId,
   });
   const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
-    config: params.cfg,
-    agentId: sessionAgentId,
-    workspaceDir,
-    cwd: process.cwd(),
-    runtime: {
-      host: "unknown",
-      os: "unknown",
-      arch: "unknown",
-      node: process.version,
-      model: `${params.provider}/${params.model}`,
-      defaultModel: defaultModelLabel,
-    },
-  });
+  const { runtimeInfo, userTimezone, userTime, userTimeFormat, personaProfile } =
+    buildSystemPromptParams({
+      config: params.cfg,
+      agentId: sessionAgentId,
+      workspaceDir,
+      cwd: process.cwd(),
+      runtime: {
+        host: "unknown",
+        os: "unknown",
+        arch: "unknown",
+        node: process.version,
+        model: `${params.provider}/${params.model}`,
+        defaultModel: defaultModelLabel,
+      },
+    });
   const sandboxInfo = sandboxRuntime.sandboxed
     ? {
         enabled: true,
@@ -114,6 +115,7 @@ export async function resolveCommandsSystemPromptBundle(
     defaultThinkLevel: params.resolvedThinkLevel,
     reasoningLevel: params.resolvedReasoningLevel,
     extraSystemPrompt: undefined,
+    personaProfile,
     ownerNumbers: undefined,
     reasoningTagHint: false,
     toolNames,

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -116,6 +116,33 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.defaults.personaProfile", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          personaProfile: "mrw-anime-experimental",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts agents.list[].personaProfile", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            personaProfile: "mrw-anime-experimental",
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects relative iMessage attachment roots", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -136,6 +136,11 @@ export type AgentDefaultsConfig = {
   bootstrapTotalMaxChars?: number;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
+  /**
+   * Optional persona profile id used to inject an additional runtime persona block
+   * into the system prompt.
+   */
+  personaProfile?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */
   timeFormat?: "auto" | "12" | "24";
   /**

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -11,6 +11,8 @@ export type AgentConfig = {
   name?: string;
   workspace?: string;
   agentDir?: string;
+  /** Optional persona profile id (overrides agents.defaults.personaProfile for this agent). */
+  personaProfile?: string;
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -37,6 +37,7 @@ export const AgentDefaultsSchema = z
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     userTimezone: z.string().optional(),
+    personaProfile: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),
     envelopeTimestamp: z.union([z.literal("on"), z.literal("off")]).optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -677,6 +677,7 @@ export const AgentEntrySchema = z
     name: z.string().optional(),
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
+    personaProfile: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,


### PR DESCRIPTION
## Summary
- add `personaProfile` config support on both `agents.defaults` and `agents.list[]`
- resolve effective persona profile per agent (agent override > defaults)
- inject a persona profile section into system prompt generation, including an experimental `mrw-anime-experimental` preset (Mr.W + anime-inspired style guidance without copyrighted dialogue)
- plumb persona profile through embedded runner, CLI runner, and commands prompt bundle paths
- add focused tests for prompt params resolution, prompt rendering, and config schema acceptance

## Testing
- corepack pnpm exec vitest run --config vitest.unit.config.ts src/agents/system-prompt-params.test.ts src/agents/system-prompt.test.ts src/config/config.schema-regressions.test.ts
- corepack pnpm exec oxfmt --check src/agents/agent-scope.ts src/agents/cli-runner/helpers.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/system-prompt.ts src/agents/system-prompt-params.test.ts src/agents/system-prompt-params.ts src/agents/system-prompt.test.ts src/agents/system-prompt.ts src/auto-reply/reply/commands-system-prompt.ts src/config/config.schema-regressions.test.ts src/config/types.agent-defaults.ts src/config/types.agents.ts src/config/zod-schema.agent-defaults.ts src/config/zod-schema.agent-runtime.ts

Closes #4
