### PR TITLE
Infra: add hashline-safe supervisor note update flow

### DIFF
--- a/src/infra/hashline-note-update.test.ts
+++ b/src/infra/hashline-note-update.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHashlineAnchors,
+  readHashlineSection,
+  upsertHashlineSection,
+} from "./hashline-note-update.js";
+
+describe("hashline-note-update", () => {
+  it("replaces section content when hashline anchors already exist", () => {
+    const key = "supervisor-checks";
+    const { start, end } = buildHashlineAnchors(key);
+    const original = `# Issue\n\n## Notes\n\n${start}\nold value\n${end}\n`;
+
+    const next = upsertHashlineSection({
+      content: original,
+      sectionKey: key,
+      sectionContent: "new value",
+      insertAfter: "## Notes",
+    });
+
+    expect(next).toContain(`${start}\nnew value\n${end}`);
+    expect(next).not.toContain("old value");
+    expect(readHashlineSection({ content: next, sectionKey: key })).toBe("new value");
+  });
+
+  it("inserts an anchored section after a stable heading when markers are missing", () => {
+    const key = "supervisor-checks";
+    const { start, end } = buildHashlineAnchors(key);
+    const original = "# Issue\n\n## Notes\n- existing\n";
+
+    const next = upsertHashlineSection({
+      content: original,
+      sectionKey: key,
+      sectionContent: "new value",
+      insertAfter: "## Notes",
+    });
+
+    expect(next).toContain(`${start}\nnew value\n${end}`);
+    expect(next.indexOf(start)).toBeGreaterThan(next.indexOf("## Notes"));
+    expect(next.indexOf(start)).toBeLessThan(next.indexOf("- existing"));
+  });
+
+  it("appends anchored section safely when insertion anchor is missing", () => {
+    const key = "supervisor-checks";
+    const { start, end } = buildHashlineAnchors(key);
+    const original = "# Issue\n\nNo heading here\n";
+
+    const next = upsertHashlineSection({
+      content: original,
+      sectionKey: key,
+      sectionContent: "new value",
+      insertAfter: "## Notes",
+    });
+
+    expect(next.endsWith(`${start}\nnew value\n${end}\n`)).toBe(true);
+    expect(next).toContain("No heading here");
+  });
+});

--- a/src/infra/hashline-note-update.ts
+++ b/src/infra/hashline-note-update.ts
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+
+const HASHLINE_PREFIX = "<!-- opencrab-hashline:";
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+function normalizeContent(value: string): string {
+  return value.replace(/\r\n/g, "\n").trimEnd();
+}
+
+function trimOneLeadingNewline(value: string): string {
+  if (value.startsWith("\r\n")) {
+    return value.slice(2);
+  }
+  if (value.startsWith("\n")) {
+    return value.slice(1);
+  }
+  return value;
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+export function buildHashlineAnchors(sectionKey: string): { start: string; end: string } {
+  const digest = shortHash(sectionKey);
+  return {
+    start: `${HASHLINE_PREFIX}${sectionKey}:${digest}:begin -->`,
+    end: `${HASHLINE_PREFIX}${sectionKey}:${digest}:end -->`,
+  };
+}
+
+function buildAnchoredBlock(params: { sectionKey: string; sectionContent: string }): string {
+  const anchors = buildHashlineAnchors(params.sectionKey);
+  const body = normalizeContent(params.sectionContent);
+  return `${anchors.start}\n${body}\n${anchors.end}\n`;
+}
+
+function findInsertPoint(content: string, insertAfter: string | RegExp): number | null {
+  if (typeof insertAfter === "string") {
+    const index = content.indexOf(insertAfter);
+    if (index < 0) {
+      return null;
+    }
+    const endOfLine = content.indexOf("\n", index + insertAfter.length);
+    return endOfLine < 0 ? content.length : endOfLine + 1;
+  }
+
+  const match = insertAfter.exec(content);
+  if (!match || typeof match.index !== "number") {
+    return null;
+  }
+  return match.index + match[0].length;
+}
+
+function insertBlock(params: {
+  content: string;
+  block: string;
+  insertAfter?: string | RegExp;
+}): string {
+  const block = ensureTrailingNewline(params.block);
+  const insertPoint = params.insertAfter
+    ? findInsertPoint(params.content, params.insertAfter)
+    : null;
+
+  if (insertPoint === null) {
+    const base = normalizeContent(params.content);
+    if (!base) {
+      return block;
+    }
+    return `${base}\n\n${block}`;
+  }
+
+  const before = params.content.slice(0, insertPoint);
+  const after = params.content.slice(insertPoint);
+  const beforeSpacer = before.endsWith("\n\n") ? "" : before.endsWith("\n") ? "\n" : "\n\n";
+  const afterSpacer = after.startsWith("\n") || after.length === 0 ? "" : "\n";
+  return `${before}${beforeSpacer}${block}${afterSpacer}${after}`;
+}
+
+export function readHashlineSection(params: {
+  content: string;
+  sectionKey: string;
+}): string | null {
+  const anchors = buildHashlineAnchors(params.sectionKey);
+  const pattern = new RegExp(
+    `${escapeForRegExp(anchors.start)}\\n?([\\s\\S]*?)\\n?${escapeForRegExp(anchors.end)}`,
+    "m",
+  );
+  const match = pattern.exec(params.content);
+  if (!match || typeof match[1] !== "string") {
+    return null;
+  }
+  return normalizeContent(match[1]);
+}
+
+export function upsertHashlineSection(params: {
+  content: string;
+  sectionKey: string;
+  sectionContent: string;
+  insertAfter?: string | RegExp;
+}): string {
+  const anchors = buildHashlineAnchors(params.sectionKey);
+  const block = buildAnchoredBlock({
+    sectionKey: params.sectionKey,
+    sectionContent: params.sectionContent,
+  });
+  const startIndex = params.content.indexOf(anchors.start);
+  if (startIndex < 0) {
+    return insertBlock({ content: params.content, block, insertAfter: params.insertAfter });
+  }
+
+  const endIndex = params.content.indexOf(anchors.end, startIndex + anchors.start.length);
+  if (endIndex < 0) {
+    // Corrupted marker pair: append a fresh block rather than risking destructive edits.
+    return insertBlock({ content: params.content, block, insertAfter: params.insertAfter });
+  }
+
+  const before = params.content.slice(0, startIndex);
+  const after = trimOneLeadingNewline(params.content.slice(endIndex + anchors.end.length));
+  return `${before}${block}${after}`;
+}

--- a/src/infra/issue-supervisor-note-updates.test.ts
+++ b/src/infra/issue-supervisor-note-updates.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readHashlineSection } from "./hashline-note-update.js";
+import {
+  appendIssueSupervisorNoteEntry,
+  appendIssueSupervisorNoteEntryToFile,
+  ISSUE_SUPERVISOR_SECTION_KEY,
+} from "./issue-supervisor-note-updates.js";
+
+describe("issue-supervisor-note-updates", () => {
+  it("adds supervisor entry into a hashline-anchored section", () => {
+    const original = "# Issue #9\n\n## Notes\n- existing\n";
+    const entry = "[2026-03-03 19:51 KST] supervisor check\n- status: active";
+
+    const next = appendIssueSupervisorNoteEntry({ content: original, entry });
+
+    const section = readHashlineSection({
+      content: next,
+      sectionKey: ISSUE_SUPERVISOR_SECTION_KEY,
+    });
+    expect(section).toContain(entry);
+  });
+
+  it("keeps repeated supervisor entries idempotent", () => {
+    const original = "# Issue #9\n\n## Notes\n";
+    const entry = "[2026-03-03 19:51 KST] supervisor check\n- status: active";
+
+    const once = appendIssueSupervisorNoteEntry({ content: original, entry });
+    const twice = appendIssueSupervisorNoteEntry({ content: once, entry });
+
+    expect(twice).toBe(once);
+  });
+
+  it("creates note file on first write and appends future entries safely", async () => {
+    const root = await mkdtemp(join(tmpdir(), "issue-supervisor-note-"));
+    const notePath = join(root, "state", "issue-notes", "issue-9.supervisor.md");
+
+    const first = await appendIssueSupervisorNoteEntryToFile({
+      notePath,
+      entry: "[2026-03-03 19:51 KST] supervisor check\n- status: active",
+    });
+    expect(first.updated).toBe(true);
+
+    const second = await appendIssueSupervisorNoteEntryToFile({
+      notePath,
+      entry: "[2026-03-03 19:56 KST] supervisor check\n- status: progressing",
+    });
+    expect(second.updated).toBe(true);
+
+    const persisted = await readFile(notePath, "utf8");
+    const section = readHashlineSection({
+      content: persisted,
+      sectionKey: ISSUE_SUPERVISOR_SECTION_KEY,
+    });
+    expect(section).toContain("status: active");
+    expect(section).toContain("status: progressing");
+  });
+});

--- a/src/infra/issue-supervisor-note-updates.ts
+++ b/src/infra/issue-supervisor-note-updates.ts
@@ -1,0 +1,65 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { readHashlineSection, upsertHashlineSection } from "./hashline-note-update.js";
+
+const NOTE_INSERT_ANCHOR = "## Notes";
+export const ISSUE_SUPERVISOR_SECTION_KEY = "issue-supervisor-notes";
+
+function normalizeEntry(entry: string): string {
+  return entry.replace(/\r\n/g, "\n").trim();
+}
+
+export function appendIssueSupervisorNoteEntry(params: { content: string; entry: string }): string {
+  const entry = normalizeEntry(params.entry);
+  if (!entry) {
+    return params.content;
+  }
+
+  const existing = readHashlineSection({
+    content: params.content,
+    sectionKey: ISSUE_SUPERVISOR_SECTION_KEY,
+  });
+  const existingBody = existing?.trim() ?? "";
+
+  const nextBody = existingBody.includes(entry)
+    ? existingBody
+    : existingBody
+      ? `${existingBody}\n\n${entry}`
+      : entry;
+
+  return upsertHashlineSection({
+    content: params.content,
+    sectionKey: ISSUE_SUPERVISOR_SECTION_KEY,
+    sectionContent: nextBody,
+    insertAfter: NOTE_INSERT_ANCHOR,
+  });
+}
+
+function defaultIssueSupervisorNote(): string {
+  return "# Issue Supervisor Notes\n\n## Notes\n";
+}
+
+export async function appendIssueSupervisorNoteEntryToFile(params: {
+  notePath: string;
+  entry: string;
+}): Promise<{ updated: boolean; content: string }> {
+  let content = defaultIssueSupervisorNote();
+
+  try {
+    content = await readFile(params.notePath, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const next = appendIssueSupervisorNoteEntry({ content, entry: params.entry });
+  if (next === content) {
+    return { updated: false, content };
+  }
+
+  await mkdir(dirname(params.notePath), { recursive: true });
+  await writeFile(params.notePath, next, "utf8");
+  return { updated: true, content: next };
+}


### PR DESCRIPTION
## Summary
- add a small hashline/anchor utility for markdown section upserts so note updates are resilient to text drift
- add issue-supervisor note update helpers that append idempotent entries into an anchored section with safe fallback when markers/anchors are missing
- include focused tests for anchored replace/insert behavior and supervisor note append idempotency + file-creation path

## Testing
- `pnpm exec vitest run src/infra/hashline-note-update.test.ts src/infra/issue-supervisor-note-updates.test.ts`
- `OPENCLAW_CONFIG_DIR=/tmp/opencrab-config OPENCLAW_WORKSPACE_DIR=/tmp/opencrab-workspace docker compose run --rm --entrypoint sh openclaw-cli -lc 'pnpm exec vitest run'` *(fails in existing baseline: 22 failing files / 16 failing tests, first cluster missing `@pierre/diffs`)*
- `OPENCLAW_CONFIG_DIR=/tmp/opencrab-config OPENCLAW_WORKSPACE_DIR=/tmp/opencrab-workspace docker compose run --rm --entrypoint sh openclaw-cli -lc 'pnpm build'`

Closes #9
