### PR TITLE
Gateway: persist service-manager mode for non-systemd docker

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -11,6 +11,10 @@ import {
   writeConfigFile,
 } from "../../config/config.js";
 import { resolveIsNixMode } from "../../config/paths.js";
+import {
+  detectAndPersistLinuxGatewayServiceManagerMode,
+  renderGatewayServiceManagerModeHints,
+} from "../../daemon/service-manager-mode.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -47,6 +51,17 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
   if (!isGatewayDaemonRuntime(runtimeRaw)) {
     fail('Invalid --runtime (use "node" or "bun")');
     return;
+  }
+
+  if (process.platform === "linux") {
+    const managerMode = await detectAndPersistLinuxGatewayServiceManagerMode(cfg);
+    if (managerMode !== "systemd") {
+      fail(
+        `Gateway service install is unavailable when gateway.serviceManagerMode=${managerMode}.`,
+        renderGatewayServiceManagerModeHints(managerMode, process.env),
+      );
+      return;
+    }
   }
 
   const service = resolveGatewayService();

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -2,11 +2,12 @@ import type { Writable } from "node:stream";
 import { loadConfig } from "../../config/config.js";
 import { resolveIsNixMode } from "../../config/paths.js";
 import { checkTokenDrift } from "../../daemon/service-audit.js";
+import {
+  renderGatewayServiceManagerModeHints,
+  resolveLinuxGatewayServiceManagerMode,
+} from "../../daemon/service-manager-mode.js";
 import type { GatewayService } from "../../daemon/service.js";
-import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
-import { isSystemdUserServiceAvailable } from "../../daemon/systemd.js";
 import { resolveGatewayCredentialsFromConfig } from "../../gateway/credentials.js";
-import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
   buildDaemonServiceSnapshot,
@@ -31,11 +32,16 @@ async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
   if (process.platform !== "linux") {
     return hints;
   }
-  const systemdAvailable = await isSystemdUserServiceAvailable().catch(() => false);
-  if (systemdAvailable) {
+  let mode = resolveLinuxGatewayServiceManagerMode(undefined, process.env);
+  try {
+    mode = resolveLinuxGatewayServiceManagerMode(loadConfig(), process.env);
+  } catch {
+    // keep fallback mode
+  }
+  if (mode === "systemd") {
     return hints;
   }
-  return [...hints, ...renderSystemdUnavailableHints({ wsl: await isWSL() })];
+  return [...hints, ...renderGatewayServiceManagerModeHints(mode, process.env)];
 }
 
 function createActionIO(params: { action: DaemonAction; json: boolean }) {

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -1,3 +1,4 @@
+import { loadConfig } from "../../config/config.js";
 import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
@@ -5,6 +6,10 @@ import {
 } from "../../daemon/constants.js";
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
 import { formatRuntimeStatus } from "../../daemon/runtime-format.js";
+import {
+  renderGatewayServiceManagerModeHints,
+  resolveLinuxGatewayServiceManagerMode,
+} from "../../daemon/service-manager-mode.js";
 import { getResolvedLoggerSettings } from "../../logging.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";
@@ -171,6 +176,15 @@ export function renderGatewayServiceStartHints(env: NodeJS.ProcessEnv = process.
       return [...base, `launchctl bootstrap gui/$UID ~/Library/LaunchAgents/${label}.plist`];
     }
     case "linux": {
+      let mode = resolveLinuxGatewayServiceManagerMode(undefined, env);
+      try {
+        mode = resolveLinuxGatewayServiceManagerMode(loadConfig(), env);
+      } catch {
+        // keep fallback mode
+      }
+      if (mode !== "systemd") {
+        return [...base, ...renderGatewayServiceManagerModeHints(mode, env)];
+      }
       const unit = resolveGatewaySystemdServiceName(profile);
       return [...base, `systemctl --user start ${unit}.service`];
     }

--- a/src/commands/configure.daemon.ts
+++ b/src/commands/configure.daemon.ts
@@ -1,5 +1,9 @@
 import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
+import {
+  detectAndPersistLinuxGatewayServiceManagerMode,
+  renderGatewayServiceManagerModeHints,
+} from "../daemon/service-manager-mode.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
@@ -19,6 +23,14 @@ export async function maybeInstallDaemon(params: {
   gatewayToken?: string;
   daemonRuntime?: GatewayDaemonRuntime;
 }) {
+  if (process.platform === "linux") {
+    const managerMode = await detectAndPersistLinuxGatewayServiceManagerMode();
+    if (managerMode !== "systemd") {
+      note(renderGatewayServiceManagerModeHints(managerMode).join("\n"), "Gateway service");
+      return;
+    }
+  }
+
   const service = resolveGatewayService();
   const loaded = await service.isLoaded({ env: process.env });
   let shouldCheckLinger = false;

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -12,9 +12,13 @@ import {
   launchAgentPlistExists,
   repairLaunchAgentBootstrap,
 } from "../daemon/launchd.js";
+import {
+  detectLinuxGatewayServiceManagerMode,
+  renderGatewayServiceManagerModeHints,
+  resolveConfiguredGatewayServiceManagerMode,
+} from "../daemon/service-manager-mode.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
-import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { isWSL } from "../infra/wsl.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -97,6 +101,25 @@ export async function maybeRepairGatewayDaemon(params: {
     return;
   }
 
+  const configuredLinuxServiceManagerMode =
+    process.platform === "linux" ? resolveConfiguredGatewayServiceManagerMode(params.cfg) : null;
+  const detectedLinuxServiceManagerMode =
+    process.platform === "linux" ? await detectLinuxGatewayServiceManagerMode() : null;
+  if (
+    configuredLinuxServiceManagerMode &&
+    detectedLinuxServiceManagerMode &&
+    configuredLinuxServiceManagerMode !== detectedLinuxServiceManagerMode
+  ) {
+    note(
+      [
+        `Configured gateway.serviceManagerMode=${configuredLinuxServiceManagerMode}.`,
+        `Runtime probe detected ${detectedLinuxServiceManagerMode}.`,
+        `Update with: ${formatCliCommand(`openclaw config set gateway.serviceManagerMode ${detectedLinuxServiceManagerMode}`)}`,
+      ].join("\n"),
+      "Gateway service mode",
+    );
+  }
+
   const service = resolveGatewayService();
   // systemd can throw in containers/WSL; treat as "not loaded" and fall back to hints.
   let loaded = false;
@@ -149,7 +172,14 @@ export async function maybeRepairGatewayDaemon(params: {
 
   if (!loaded) {
     if (process.platform === "linux") {
-      const systemdAvailable = await isSystemdUserServiceAvailable().catch(() => false);
+      if (configuredLinuxServiceManagerMode && configuredLinuxServiceManagerMode !== "systemd") {
+        note(
+          renderGatewayServiceManagerModeHints(configuredLinuxServiceManagerMode).join("\n"),
+          "Gateway",
+        );
+        return;
+      }
+      const systemdAvailable = (detectedLinuxServiceManagerMode ?? "systemd") === "systemd";
       if (!systemdAvailable) {
         const wsl = await isWSL();
         note(renderSystemdUnavailableHints({ wsl }).join("\n"), "Gateway");

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
+import { detectAndPersistLinuxGatewayServiceManagerMode } from "../../daemon/service-manager-mode.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import { applyOnboardingLocalWorkspaceConfig } from "../onboard-config.js";
@@ -84,6 +85,10 @@ export async function runNonInteractiveOnboardingLocal(params: {
   await ensureWorkspaceAndSessions(workspaceDir, runtime, {
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
   });
+
+  if (process.platform === "linux") {
+    await detectAndPersistLinuxGatewayServiceManagerMode(nextConfig).catch(() => undefined);
+  }
 
   if (opts.installDaemon) {
     const { installGatewayDaemonNonInteractive } = await import("./local/daemon-install.js");

--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  detectAndPersistLinuxGatewayServiceManagerMode,
+  renderGatewayServiceManagerModeHints,
+} from "../../../daemon/service-manager-mode.js";
 import { resolveGatewayService } from "../../../daemon/service.js";
-import { isSystemdUserServiceAvailable } from "../../../daemon/systemd.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { buildGatewayInstallPlan, gatewayInstallErrorHint } from "../../daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, isGatewayDaemonRuntime } from "../../daemon-runtime.js";
@@ -20,17 +23,23 @@ export async function installGatewayDaemonNonInteractive(params: {
   }
 
   const daemonRuntimeRaw = opts.daemonRuntime ?? DEFAULT_GATEWAY_DAEMON_RUNTIME;
-  const systemdAvailable =
-    process.platform === "linux" ? await isSystemdUserServiceAvailable() : true;
-  if (process.platform === "linux" && !systemdAvailable) {
-    runtime.log("Systemd user services are unavailable; skipping service install.");
-    return;
-  }
-
   if (!isGatewayDaemonRuntime(daemonRuntimeRaw)) {
     runtime.error("Invalid --daemon-runtime (use node or bun)");
     runtime.exit(1);
     return;
+  }
+
+  if (process.platform === "linux") {
+    const managerMode = await detectAndPersistLinuxGatewayServiceManagerMode(params.nextConfig);
+    if (managerMode !== "systemd") {
+      runtime.log(
+        [
+          `gateway.serviceManagerMode=${managerMode}; skipping service install.`,
+          ...renderGatewayServiceManagerModeHints(managerMode, process.env),
+        ].join("\n"),
+      );
+      return;
+    }
   }
 
   const service = resolveGatewayService();

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -315,6 +315,8 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+export type GatewayServiceManagerMode = "systemd" | "supervisor" | "none";
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -323,6 +325,11 @@ export type GatewayConfig = {
    * When set to "local", the CLI may start the gateway locally.
    */
   mode?: "local" | "remote";
+  /**
+   * Persisted service-manager capability detected during onboarding/install.
+   * Linux defaults to systemd unless container/supervisor mode is detected.
+   */
+  serviceManagerMode?: GatewayServiceManagerMode;
   /**
    * Bind address policy for the Gateway WebSocket + Control UI HTTP server.
    * - auto: Loopback (127.0.0.1) if available, else 0.0.0.0 (fallback to all interfaces)

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -522,6 +522,9 @@ export const OpenClawSchema = z
       .object({
         port: z.number().int().positive().optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
+        serviceManagerMode: z
+          .union([z.literal("systemd"), z.literal("supervisor"), z.literal("none")])
+          .optional(),
         bind: z
           .union([
             z.literal("auto"),

--- a/src/daemon/service-manager-mode.test.ts
+++ b/src/daemon/service-manager-mode.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ""),
+}));
+
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+const readConfigFileSnapshotMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    resolved: {},
+    valid: true,
+    config: {},
+    issues: [] as Array<{ path: string; message: string }>,
+    warnings: [] as Array<{ path: string; message: string }>,
+    legacyIssues: [] as Array<{ path: string; message: string }>,
+  })),
+);
+const writeConfigFileMock = vi.hoisted(() => vi.fn(async () => {}));
+const isSystemdUserServiceAvailableMock = vi.hoisted(() => vi.fn(async () => true));
+
+vi.mock("node:fs", () => ({
+  default: fsMock,
+  existsSync: fsMock.existsSync,
+  readFileSync: fsMock.readFileSync,
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+  readConfigFileSnapshot: readConfigFileSnapshotMock,
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("./systemd.js", () => ({
+  isSystemdUserServiceAvailable: isSystemdUserServiceAvailableMock,
+}));
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T> | T): Promise<T> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  }
+}
+
+describe("service-manager-mode", () => {
+  beforeEach(() => {
+    fsMock.existsSync.mockReset();
+    fsMock.readFileSync.mockReset();
+    loadConfigMock.mockReset();
+    readConfigFileSnapshotMock.mockReset();
+    writeConfigFileMock.mockReset();
+    isSystemdUserServiceAvailableMock.mockReset();
+
+    fsMock.existsSync.mockReturnValue(false);
+    fsMock.readFileSync.mockReturnValue("");
+    loadConfigMock.mockReturnValue({});
+    readConfigFileSnapshotMock.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: {},
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+    isSystemdUserServiceAvailableMock.mockResolvedValue(true);
+  });
+
+  it("prefers persisted gateway.serviceManagerMode when present", async () => {
+    const { resolveLinuxGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    await withPlatform("linux", () => {
+      expect(
+        resolveLinuxGatewayServiceManagerMode({
+          gateway: { serviceManagerMode: "none" },
+        }),
+      ).toBe("none");
+    });
+  });
+
+  it("falls back to supervisor mode in containerized linux environments", async () => {
+    const { resolveLinuxGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    await withPlatform("linux", () => {
+      expect(
+        resolveLinuxGatewayServiceManagerMode({}, { container: "docker" } as NodeJS.ProcessEnv),
+      ).toBe("supervisor");
+    });
+  });
+
+  it("defaults to systemd mode on linux when no container hint exists", async () => {
+    const { resolveLinuxGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    await withPlatform("linux", () => {
+      expect(resolveLinuxGatewayServiceManagerMode({}, {} as NodeJS.ProcessEnv)).toBe("systemd");
+    });
+  });
+
+  it("maps systemd probe result to detected mode", async () => {
+    const { detectLinuxGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    await withPlatform("linux", async () => {
+      isSystemdUserServiceAvailableMock.mockResolvedValueOnce(true);
+      await expect(detectLinuxGatewayServiceManagerMode()).resolves.toBe("systemd");
+
+      isSystemdUserServiceAvailableMock.mockResolvedValueOnce(false);
+      await expect(detectLinuxGatewayServiceManagerMode()).resolves.toBe("supervisor");
+    });
+  });
+
+  it("persists service manager mode when changed", async () => {
+    const { persistGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: { gateway: { mode: "local" } },
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+
+    const changed = await persistGatewayServiceManagerMode({ mode: "supervisor" });
+
+    expect(changed).toBe(true);
+    expect(writeConfigFileMock).toHaveBeenCalledWith({
+      gateway: {
+        mode: "local",
+        serviceManagerMode: "supervisor",
+      },
+    });
+  });
+
+  it("skips writes when persisted mode already matches", async () => {
+    const { persistGatewayServiceManagerMode } = await import("./service-manager-mode.js");
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: { gateway: { serviceManagerMode: "systemd" } },
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+
+    const changed = await persistGatewayServiceManagerMode({ mode: "systemd" });
+
+    expect(changed).toBe(false);
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/service-manager-mode.ts
+++ b/src/daemon/service-manager-mode.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import { formatCliCommand } from "../cli/command-format.js";
+import { loadConfig, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import type { GatewayServiceManagerMode } from "../config/types.gateway.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { isSystemdUserServiceAvailable } from "./systemd.js";
+
+const GATEWAY_SERVICE_MANAGER_MODES: GatewayServiceManagerMode[] = [
+  "systemd",
+  "supervisor",
+  "none",
+];
+
+const GATEWAY_SERVICE_MANAGER_MODE_SET = new Set<GatewayServiceManagerMode>(
+  GATEWAY_SERVICE_MANAGER_MODES,
+);
+
+export function isGatewayServiceManagerMode(value: unknown): value is GatewayServiceManagerMode {
+  return (
+    typeof value === "string" &&
+    GATEWAY_SERVICE_MANAGER_MODE_SET.has(value as GatewayServiceManagerMode)
+  );
+}
+
+export function resolveConfiguredGatewayServiceManagerMode(
+  cfg: OpenClawConfig | null | undefined,
+): GatewayServiceManagerMode | null {
+  const raw = cfg?.gateway?.serviceManagerMode;
+  if (!isGatewayServiceManagerMode(raw)) {
+    return null;
+  }
+  return raw;
+}
+
+function readContainerCgroupHint(): string {
+  try {
+    return fs.readFileSync("/proc/1/cgroup", "utf8").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+export function isLikelyContainerizedLinux(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  const containerHint = env.container?.trim().toLowerCase();
+  if (containerHint && containerHint !== "0" && containerHint !== "false") {
+    return true;
+  }
+  if (fs.existsSync("/.dockerenv")) {
+    return true;
+  }
+  const cgroup = readContainerCgroupHint();
+  return (
+    cgroup.includes("docker") ||
+    cgroup.includes("containerd") ||
+    cgroup.includes("kubepods") ||
+    cgroup.includes("podman")
+  );
+}
+
+export function resolveLinuxGatewayServiceManagerMode(
+  cfg: OpenClawConfig | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): GatewayServiceManagerMode {
+  if (process.platform !== "linux") {
+    return "none";
+  }
+  const configured = resolveConfiguredGatewayServiceManagerMode(cfg);
+  if (configured) {
+    return configured;
+  }
+  // Legacy configs may not have a persisted mode yet; container detection keeps
+  // Docker paths from hard-failing on systemd assumptions.
+  return isLikelyContainerizedLinux(env) ? "supervisor" : "systemd";
+}
+
+export async function detectLinuxGatewayServiceManagerMode(): Promise<GatewayServiceManagerMode> {
+  if (process.platform !== "linux") {
+    return "none";
+  }
+  const available = await isSystemdUserServiceAvailable().catch(() => false);
+  return available ? "systemd" : "supervisor";
+}
+
+export function renderGatewayServiceManagerModeHints(
+  mode: GatewayServiceManagerMode,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (mode === "systemd") {
+    return [];
+  }
+  const runForeground = formatCliCommand("openclaw gateway", env);
+  if (mode === "supervisor") {
+    return [
+      `Gateway service manager mode is "supervisor"; run ${runForeground} under Docker Compose, Kubernetes, or your process supervisor.`,
+    ];
+  }
+  return [
+    `Gateway service manager mode is "none"; background service management commands are disabled.`,
+    `Run in foreground: ${runForeground}`,
+  ];
+}
+
+export function applyGatewayServiceManagerMode(
+  cfg: OpenClawConfig,
+  mode: GatewayServiceManagerMode,
+): OpenClawConfig {
+  return {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      serviceManagerMode: mode,
+    },
+  };
+}
+
+function safeLoadConfigForServiceManagerMode(): OpenClawConfig {
+  try {
+    return loadConfig();
+  } catch {
+    return {};
+  }
+}
+
+export async function persistGatewayServiceManagerMode(params: {
+  mode: GatewayServiceManagerMode;
+  baseConfig?: OpenClawConfig;
+}): Promise<boolean> {
+  const { mode, baseConfig } = params;
+  const snapshot = await readConfigFileSnapshot().catch(() => null);
+  if (snapshot?.exists && !snapshot.valid) {
+    return false;
+  }
+  const sourceConfig = baseConfig ?? snapshot?.config ?? safeLoadConfigForServiceManagerMode();
+  if (resolveConfiguredGatewayServiceManagerMode(sourceConfig) === mode) {
+    return false;
+  }
+  await writeConfigFile(applyGatewayServiceManagerMode(sourceConfig, mode));
+  return true;
+}
+
+export async function detectAndPersistLinuxGatewayServiceManagerMode(
+  baseConfig?: OpenClawConfig,
+): Promise<GatewayServiceManagerMode> {
+  const mode = await detectLinuxGatewayServiceManagerMode();
+  await persistGatewayServiceManagerMode({ mode, baseConfig }).catch(() => undefined);
+  return mode;
+}

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T> | T): Promise<T> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  }
+}
+
+describe("resolveGatewayService linux mode resolution", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({});
+  });
+
+  it("returns supervisor-backed service when gateway.serviceManagerMode=supervisor", async () => {
+    const { resolveGatewayService } = await import("./service.js");
+    await withPlatform("linux", async () => {
+      loadConfigMock.mockReturnValueOnce({
+        gateway: {
+          serviceManagerMode: "supervisor",
+        },
+      });
+      const service = resolveGatewayService();
+      expect(service.label).toBe("supervisor");
+      await expect(
+        service.install({
+          env: process.env,
+          stdout: process.stdout,
+          programArguments: ["openclaw", "gateway"],
+        }),
+      ).rejects.toThrow("gateway.serviceManagerMode=supervisor");
+      await expect(service.isLoaded({ env: process.env })).resolves.toBe(false);
+    });
+  });
+
+  it("returns systemd service when gateway.serviceManagerMode=systemd", async () => {
+    const { resolveGatewayService } = await import("./service.js");
+    await withPlatform("linux", () => {
+      loadConfigMock.mockReturnValueOnce({
+        gateway: {
+          serviceManagerMode: "systemd",
+        },
+      });
+      const service = resolveGatewayService();
+      expect(service.label).toBe("systemd");
+    });
+  });
+
+  it("falls back to supervisor mode in containerized linux when config is unavailable", async () => {
+    const { resolveGatewayService } = await import("./service.js");
+    await withPlatform("linux", () => {
+      loadConfigMock.mockImplementationOnce(() => {
+        throw new Error("invalid config");
+      });
+      const originalContainer = process.env.container;
+      process.env.container = "docker";
+      try {
+        const service = resolveGatewayService();
+        expect(service.label).toBe("supervisor");
+      } finally {
+        if (originalContainer === undefined) {
+          delete process.env.container;
+        } else {
+          process.env.container = originalContainer;
+        }
+      }
+    });
+  });
+});

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -1,3 +1,5 @@
+import { loadConfig } from "../config/config.js";
+import type { GatewayServiceManagerMode } from "../config/types.gateway.js";
 import {
   installLaunchAgent,
   isLaunchAgentLoaded,
@@ -16,6 +18,10 @@ import {
   stopScheduledTask,
   uninstallScheduledTask,
 } from "./schtasks.js";
+import {
+  renderGatewayServiceManagerModeHints,
+  resolveLinuxGatewayServiceManagerMode,
+} from "./service-manager-mode.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -51,6 +57,48 @@ function ignoreInstallResult(
   };
 }
 
+function resolveLinuxServiceManagerModeCached(): GatewayServiceManagerMode {
+  try {
+    return resolveLinuxGatewayServiceManagerMode(loadConfig(), process.env);
+  } catch {
+    return resolveLinuxGatewayServiceManagerMode(undefined, process.env);
+  }
+}
+
+function createExternallyManagedService(mode: GatewayServiceManagerMode): GatewayService {
+  const hints = renderGatewayServiceManagerModeHints(mode, process.env);
+  const detail =
+    hints[0] ??
+    `Gateway service manager mode is "${mode}". Use ${process.platform} process supervision.`;
+  const unsupported = (action: string) =>
+    new Error(`${action} is unavailable when gateway.serviceManagerMode=${mode}. ${detail}`.trim());
+  const label = mode === "supervisor" ? "supervisor" : "service manager";
+  return {
+    label,
+    loadedText: "managed",
+    notLoadedText: "not managed by OpenClaw",
+    install: async () => {
+      throw unsupported("Gateway service install");
+    },
+    uninstall: async () => {
+      throw unsupported("Gateway service uninstall");
+    },
+    stop: async () => {
+      throw unsupported("Gateway service stop");
+    },
+    restart: async () => {
+      throw unsupported("Gateway service restart");
+    },
+    isLoaded: async () => false,
+    readCommand: async () => null,
+    readRuntime: async () => ({
+      status: "unknown",
+      detail,
+      cachedLabel: true,
+    }),
+  };
+}
+
 export type GatewayService = {
   label: string;
   loadedText: string;
@@ -81,6 +129,10 @@ export function resolveGatewayService(): GatewayService {
   }
 
   if (process.platform === "linux") {
+    const managerMode = resolveLinuxServiceManagerModeCached();
+    if (managerMode !== "systemd") {
+      return createExternallyManagedService(managerMode);
+    }
     return {
       label: "systemd",
       loadedText: "enabled",

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -22,8 +22,11 @@ import {
 } from "../commands/onboard-helpers.js";
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  detectAndPersistLinuxGatewayServiceManagerMode,
+  renderGatewayServiceManagerModeHints,
+} from "../daemon/service-manager-mode.js";
 import { resolveGatewayService } from "../daemon/service.js";
-import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { restoreTerminalState } from "../terminal/restore.js";
@@ -62,12 +65,19 @@ export async function finalizeOnboardingWizard(
     }
   };
 
+  const linuxServiceManagerMode =
+    process.platform === "linux"
+      ? await detectAndPersistLinuxGatewayServiceManagerMode(nextConfig)
+      : "none";
   const systemdAvailable =
-    process.platform === "linux" ? await isSystemdUserServiceAvailable() : true;
+    process.platform === "linux" ? linuxServiceManagerMode === "systemd" : true;
   if (process.platform === "linux" && !systemdAvailable) {
     await prompter.note(
-      "Systemd user services are unavailable. Skipping lingering checks and service install.",
-      "Systemd",
+      [
+        `gateway.serviceManagerMode=${linuxServiceManagerMode}.`,
+        ...renderGatewayServiceManagerModeHints(linuxServiceManagerMode, process.env),
+      ].join("\n"),
+      "Gateway service",
     );
   }
 
@@ -103,7 +113,10 @@ export async function finalizeOnboardingWizard(
 
   if (process.platform === "linux" && !systemdAvailable && installDaemon) {
     await prompter.note(
-      "Systemd user services are unavailable; skipping service install. Use your container supervisor or `docker compose up -d`.",
+      [
+        "Systemd user services are unavailable; skipping service install.",
+        ...renderGatewayServiceManagerModeHints(linuxServiceManagerMode, process.env),
+      ].join("\n"),
       "Gateway service",
     );
     installDaemon = false;


### PR DESCRIPTION
## Summary
- add persisted `gateway.serviceManagerMode` (`systemd|supervisor|none`) to config schema/types
- detect and cache Linux service-manager mode during onboarding/install, then use cached mode in daemon/service flows
- make non-systemd Docker/supervisor environments fail gracefully with actionable hints instead of systemd hard assumptions
- add doctor drift warning when configured mode differs from runtime re-detect

## Verification (already run)
- `pnpm vitest src/daemon/service-manager-mode.test.ts src/daemon/service.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/cli/daemon-cli/shared.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/wizard/onboarding.test.ts` (6 files, 22 tests passed)
- `pnpm tsgo`
- `pnpm lint`
- `docker run --rm -v "$PWD":/repo -w /repo node:22-bookworm bash -lc '... pnpm vitest ...; pnpm tsgo'` (passed)
- `docker run --rm -v "$PWD":/repo -w /repo node:22-bookworm bash -lc '... node openclaw.mjs gateway install --json ...'` (expected non-zero; output includes `gateway.serviceManagerMode=supervisor`)

Closes #12
